### PR TITLE
Update fits_dict.py

### DIFF
--- a/train/fits_dict.py
+++ b/train/fits_dict.py
@@ -61,7 +61,7 @@ class FitsDict():
 
     def flip_pose(self, pose, is_flipped):
         """flip SMPL pose parameters"""
-        is_flipped = is_flipped.byte()
+        is_flipped = is_flipped.bool()
         pose_f = pose.clone()
         pose_f[is_flipped, :] = pose[is_flipped][:, self.flipped_parts]
         # we also negate the second and the third dimension of the axis-angle representation


### PR DESCRIPTION
to avoid warning 
/pytorch/aten/src/ATen/native/IndexingUtils.h:20: UserWarning: indexing with dtype torch.uint8 is now deprecated, please use a dtype torch.bool instead.
flip_pose should be casted to bool not byte (=uint8) for proper indexing 