### PR TITLE
Load checkpoint onto the same device as the model

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -102,7 +102,7 @@ if __name__ == '__main__':
     
     # Load pretrained model
     model = hmr(config.SMPL_MEAN_PARAMS).to(device)
-    checkpoint = torch.load(args.checkpoint)
+    checkpoint = torch.load(args.checkpoint, map_location=device)
     model.load_state_dict(checkpoint['model'], strict=False)
 
     # Load SMPL model


### PR DESCRIPTION
I propose this change to make it easier for people to get the demo working out of the box, in particular on a CPU.