### PR TITLE
Reduce rounding error on coordinates in transform

### DIFF
--- a/utils/imutils.py
+++ b/utils/imutils.py
@@ -41,7 +41,7 @@ def transform(pt, center, scale, res, invert=0, rot=0):
         t = np.linalg.inv(t)
     new_pt = np.array([pt[0]-1, pt[1]-1, 1.]).T
     new_pt = np.dot(t, new_pt)
-    return new_pt[:2].astype(int)+1
+    return np.rint(new_pt[:2]).astype(int)
 
 def crop(img, center, scale, res, rot=0):
     """Crop image according to the supplied bounding box."""


### PR DESCRIPTION
Current implementation found to map 2D key points with error margin.
Testing e.g. found that the point (0, 0) is mapped to (3, 3).
Generally, absolute error falls in range [0; 3].
Proposed change reduces range to [0; 1].
Removing rounding + conversion to int eliminates error completely, but side effect on function "crop()" which uses "transform()" not tested. Hence, this solution appears more robust until testing on "crop()" is done.